### PR TITLE
added variable status, correct set/get definition

### DIFF
--- a/monologue/Controller.hx
+++ b/monologue/Controller.hx
@@ -184,7 +184,8 @@ class Controller
 			{
 				mVar.value = node.value;
 				host.onSetVariable(VariableState.SUCCESS, mVar.displayName, mVar.value);
-			} else {
+			} else 
+			{
 				host.onSetVariable(VariableState.ERROR_UNSETTABLE, mVar.displayName, mVar.value);
 			}
 		}

--- a/monologue/Controller.hx
+++ b/monologue/Controller.hx
@@ -184,7 +184,8 @@ class Controller
 			{
 				mVar.value = node.value;
 				host.onSetVariable(VariableState.SUCCESS, mVar.displayName, mVar.value);
-			} else 
+			} 
+			else
 			{
 				host.onSetVariable(VariableState.ERROR_UNSETTABLE, mVar.displayName, mVar.value);
 			}

--- a/monologue/Controller.hx
+++ b/monologue/Controller.hx
@@ -180,7 +180,8 @@ class Controller
 		var mVar = monologue.getVariable(node.variable);
 		if (mVar != null)
 		{
-			if (mVar.settable) {
+			if (mVar.settable) 
+			{
 				mVar.value = node.value;
 				host.onSetVariable(VariableState.SUCCESS, mVar.displayName, mVar.value);
 			} else {

--- a/monologue/Controller.hx
+++ b/monologue/Controller.hx
@@ -180,8 +180,12 @@ class Controller
 		var mVar = monologue.getVariable(node.variable);
 		if (mVar != null)
 		{
-			mVar.value = node.value;
-			host.onSetVariable(mVar.displayName, mVar.value);
+			if (mVar.settable) {
+				mVar.value = node.value;
+				host.onSetVariable(VariableState.SUCCESS, mVar.displayName, mVar.value);
+			} else {
+				host.onSetVariable(VariableState.ERROR_UNSETTABLE, mVar.displayName, mVar.value);
+			}
 		}
 	}
 }
@@ -191,6 +195,13 @@ enum TreeState
 	PAUSED;
 	TERMINATED;
 	ERROR;
+}
+
+enum VariableState
+{
+	SUCCESS;
+	ERROR_UNSETTABLE;
+	ERROR_UNGETTABLE;
 }
 
 typedef MonologueParams = {

--- a/monologue/IMonologueHost.hx
+++ b/monologue/IMonologueHost.hx
@@ -22,6 +22,7 @@
  */
 
 package monologue;
+import monologue.Controller.VariableState;
 import monologue.MonologueTree.MonologueTreeNode;
 import monologue.MonologueTree.TreeNodeText;
 
@@ -44,5 +45,5 @@ interface IMonologueHost
 	 * @param	name
 	 * @param	value
 	 */
-	public function onSetVariable(name:String, value:Dynamic):Void;
+	public function onSetVariable(status:VariableState, name:String, value:Dynamic):Void;
 }

--- a/monologue/MonologueVariable.hx
+++ b/monologue/MonologueVariable.hx
@@ -121,9 +121,7 @@ class MonologueVariable
 	}
 	
 	private function get_value():Dynamic
-	{
-		if (!gettable) return null;
-		
+	{		
 		return switch(type)
 		{
 			case BOOL: _bool;
@@ -134,9 +132,7 @@ class MonologueVariable
 	}
 	
 	private function set_value(val:Dynamic):Dynamic
-	{
-		if (!settable) return null;
-		
+	{		
 		switch(type)
 		{
 			case BOOL:


### PR DESCRIPTION
This corrects the settable/gettable issue we discussed on Slack.

The `onSetVariable` signature changed, I added a `VariableState` enum and it gets passed as the first parameter. 

The error mechanisms still have to be implemented for `gettable`.
